### PR TITLE
Changing ttam-lintly version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def read(*parts):
 
 setup(
     name='ttam-lintly',
-    version='0.6.1',
+    version='0.6.2',
     url='https://github.com/23andMe/Lintly',
     license='MIT',
     author='Veda Nandusekar',


### PR DESCRIPTION
Changed the ttam-lintly version to 0.6.2 which includes normalized path for cfn-nag tool.