### PR TITLE
Adding github action for publishing ttam-lintly to pypi

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,32 @@
+# This workflows will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: Upload Python Package
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_LINTLY }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def read(*parts):
 
 setup(
     name='ttam-lintly',
-    version='0.6.2',
+    version='0.6.3',
     url='https://github.com/23andMe/Lintly',
     license='MIT',
     author='Veda Nandusekar',


### PR DESCRIPTION
Adding automated workflow for publishing ttam-lintly version to pypi on pushing code to master. 
With this changes we have to update setup.py with appropriate version. 