### PR TITLE
Fixing gitleaks unittest and linter errors

### DIFF
--- a/lintly/parsers.py
+++ b/lintly/parsers.py
@@ -358,10 +358,10 @@ class GitLeaksParser(BaseLintParser):
         if not output:
             return dict()
 
-        json_data = output.split("\n")
+        json_data = json.loads(output)
+
         violations = collections.defaultdict(list)
-        for violation_json in json_data:
-            violation_data = json.loads(violation_json)
+        for violation_data in json_data:
             violation = Violation(
                 line=violation_data["lineNumber"],
                 column=0,

--- a/tests/linters_output/gitleaks.json
+++ b/tests/linters_output/gitleaks.json
@@ -27,7 +27,7 @@
          "commitMessage": "Adding test cases\n",
          "author": "bob s",
          "email": "bob@example.com",
-         "file": "relative/path/to/output",
+         "file": "relative/path/to/output2",
          "date": "2021-02-23T18:59:38-08:00",
          "tags": "key, AsymmetricPrivateKey"
         }

--- a/tests/server_test.py
+++ b/tests/server_test.py
@@ -1,9 +1,4 @@
 # This are test credentials
-client = boto3.client(
-    's3',
-    # Hard coded strings as credentials, not recommended.
-    aws_access_key_id='AKIAIO5FODNN7EXAMPLE',
-    aws_secret_access_key='ABCDEF+c2L7yXeGvUyrPgYsDnWRRC1AYEXAMPLE'
-)
-
-# adding another line
+# Hard coded strings as credentials, not recommended
+aws_access_key_id = 'AKIAIO5FODNN7EXAMPLE'
+aws_secret_access_key = 'ABCDEF+c2L7yXeGvUyrPgYsDnWRRC1AYEXAMPLE'

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -130,11 +130,11 @@ class GitleaksParserTestCase(ParserTestCaseMixin, unittest.TestCase):
     parser = PARSERS['gitleaks']
     linter_output_file_name = 'gitleaks.json'
     expected_violations = {
-        'tests/server_test.py': [
+        'relative/path/to/output': [
             {'line': 5, 'column': 0, 'code': 'AKIAIO5FODNN7EXAMPLE',
              'message': 'AWS Access Key'}
         ],
-        'tests/linters_output/gitleaks.json': [
+        'relative/path/to/output2': [
             {'line': 2, 'column': 0, 'code': '-----BEGIN PRIVATE KEY-----',
              'message': 'Asymmetric Private Key'}
         ]


### PR DESCRIPTION
Flake8 was giving some warning for server_test.py. 
Those  are:
```./tests/server_test.py:2:10: F821 undefined name 'boto3'
./tests/server_test.py:9:22: W292 no newline at end of file
./tests/server_test.py:9:22: W292 no newline at end of file
./tests/server_test.py:9:22: W292 no newline at end of file