### PR TITLE
SEC-1438 Adding  Hadolint parser for Lintly

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ Now you will see a review with linting errors...
     ```
     $ gitleaks --path=. -q | lintly --format=gitleaks
     ```
+- - [hadolint](https://github.com/hadolint/hadolint)
+    ```
+    $ hadolint path/to/Dockerfile --format json |lintly --format=hadolint
+    ```
 
 - [cfn-lint](https://github.com/aws-cloudformation/cfn-python-lint)
     ```

--- a/tests/linters_output/hadolint.json
+++ b/tests/linters_output/hadolint.json
@@ -1,0 +1,18 @@
+[
+    {
+      "line": 12,
+      "code": "DL3015",
+      "message": "Avoid additional packages by specifying `--no-install-recommends`",
+      "column": 1,
+      "file": "relative/path/to/file1",
+      "level": "info"
+    },
+    {
+      "line": 19,
+      "code": "DL3020",
+      "message": "Use COPY instead of ADD for files and folders",
+      "column": 1,
+      "file": "relative/path/to/file2",
+      "level": "error"
+    }
+  ]

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -141,6 +141,21 @@ class GitleaksParserTestCase(ParserTestCaseMixin, unittest.TestCase):
     }
 
 
+class HadolintParserTestCase(ParserTestCaseMixin, unittest.TestCase):
+    parser = PARSERS['hadolint']
+    linter_output_file_name = 'hadolint.json'
+    expected_violations = {
+        'relative/path/to/file1': [
+            {'line': 12, 'column': 1, 'code': 'DL3015',
+             'message': 'Avoid additional packages by specifying `--no-install-recommends`'}
+        ],
+        'relative/path/to/file2': [
+            {'line': 19, 'column': 1, 'code': 'DL3020',
+             'message': 'Use COPY instead of ADD for files and folders'}
+        ]
+    }
+
+
 class PylintJSONParserTestCase(ParserTestCaseMixin, unittest.TestCase):
     parser = PARSERS['pylint-json']
     linter_output_file_name = 'pylint-json.txt'


### PR DESCRIPTION
Hadolint tool is used to scan Dockerfiles.
Link: https://github.com/hadolint/hadolint

This Lintly parser for Hadolint will annotate findings on PR