### PR TITLE
Adding Lintly parser for trivy

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ Now you will see a review with linting errors...
     $ terrascan scan -d path/to/terraform/file -o json |lintly --format=terrascan
     ```
 
+-  [trivy](https://github.com/aquasecurity/trivy)
+    ```
+    $ trivy --quiet fs -f json path/to/directory/ |lintly --format=trivy
+    ```
+
 - [cfn-lint](https://github.com/aws-cloudformation/cfn-python-lint)
     ```
     $ cfn-lint template.yaml | lintly --format=cfn-lint
@@ -118,7 +123,7 @@ Options:
                                   (required)
   --commit-sha TEXT               The commit Lintly is running against
                                   (required)
-  --format [unix|flake8|pylint-json|eslint|eslint-unix|stylelint|black|cfn-lint|cfn-nag|bandit-json|gitleaks|hadolint|terrascan]
+  --format [unix|flake8|pylint-json|eslint|eslint-unix|stylelint|black|cfn-lint|cfn-nag|bandit-json|gitleaks|hadolint|terrascan|trivy]
                                   The linting output format Lintly should
                                   expect to receive. Default "flake8"
   --context TEXT                  Override the commit status context

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def read(*parts):
 
 setup(
     name='ttam-lintly',
-    version='0.6.6',
+    version='0.6.7',
     url='https://github.com/23andMe/Lintly',
     license='MIT',
     author='Veda Nandusekar',

--- a/tests/linters_output/trivy.json
+++ b/tests/linters_output/trivy.json
@@ -1,0 +1,76 @@
+[
+  {
+    "Target": "relative/path/to/file1",
+    "Type": "cargo",
+    "Vulnerabilities": [
+      {
+        "VulnerabilityID": "RUSTSEC-2019-0001",
+        "PkgName": "ammonia",
+        "InstalledVersion": "1.9.0",
+        "FixedVersion": "\u003e= 2.1.0",
+        "Layer": {
+          "DiffID": "sha256:737a0ed9a3995244abfcbb7676fee2ae74c0f94e57c009a5354eab18562fc4c6"
+        },
+        "PrimaryURL": "https://rustsec.org/advisories/RUSTSEC-2019-0001",
+        "Title": "Uncontrolled recursion in HTML serialization",
+        "Description": "Affected versions of this crate did use recursion for serialization of HTML\nDOM trees.",
+        "Severity": "UNKNOWN",
+        "References": [
+          "https://github.com/rust-ammonia/ammonia/blob/master/CHANGELOG.md#210"
+        ]
+      }
+    ]
+  },
+  {
+    "Target": "relative/path/to/file2",
+    "Type": "pipenv",
+    "Vulnerabilities": [
+      {
+        "VulnerabilityID": "CVE-2019-19844",
+        "PkgName": "django",
+        "InstalledVersion": "2.0.9",
+        "FixedVersion": "3.0.1, 2.2.9, 1.11.27",
+        "Layer": {
+          "DiffID": "sha256:737a0ed9a3995244abfcbb7676fee2ae74c0f94e57c009a5354eab18562fc4c6"
+        },
+        "SeveritySource": "nvd",
+        "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2019-19844",
+        "Title": "Django: crafted email address allows account takeover",
+        "Description": "Django before 1.11.27, 2.x before 2.2.9, and 3.x before 3.0.1 allows account takeover.",
+        "Severity": "CRITICAL",
+        "CweIDs": [
+          "CWE-640"
+        ],
+        "CVSS": {
+          "nvd": {
+            "V2Vector": "AV:N/AC:L/Au:N/C:N/I:P/A:N",
+            "V3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "V2Score": 5,
+            "V3Score": 9.8
+          },
+          "redhat": {
+            "V3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "V3Score": 9.8
+          }
+        },
+        "References": [
+          "http://packetstormsecurity.com/files/155872/Django-Account-Hijack.html",
+          "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-19844",
+          "https://docs.djangoproject.com/en/dev/releases/security/",
+          "https://github.com/advisories/GHSA-vfq6-hq5r-27r6",
+          "https://groups.google.com/forum/#!topic/django-announce/3oaB2rVH3a0",
+          "https://nvd.nist.gov/vuln/detail/CVE-2019-19844",
+          "https://seclists.org/bugtraq/2020/Jan/9",
+          "https://security.gentoo.org/glsa/202004-17",
+          "https://security.netapp.com/advisory/ntap-20200110-0003/",
+          "https://usn.ubuntu.com/4224-1/",
+          "https://usn.ubuntu.com/usn/usn-4224-1",
+          "https://www.debian.org/security/2020/dsa-4598",
+          "https://www.djangoproject.com/weblog/2019/dec/18/security-releases/"
+        ],
+        "PublishedDate": "2019-12-18T19:15:00Z",
+        "LastModifiedDate": "2020-01-08T04:15:00Z"
+      }
+    ]
+  }
+]

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -171,6 +171,21 @@ class TerrascanParserTestCase(ParserTestCaseMixin, unittest.TestCase):
     }
 
 
+class TrivyParserTestCase(ParserTestCaseMixin, unittest.TestCase):
+    parser = PARSERS['trivy']
+    linter_output_file_name = 'trivy.json'
+    expected_violations = {
+        'relative/path/to/file1': [
+            {'line': 0, 'column': 0, 'code': 'RUSTSEC-2019-0001 (Uncontrolled recursion in HTML serialization)',
+             'message': 'Affected versions of this crate did use recursion for serialization of HTML\nDOM trees.'}
+        ],
+        'relative/path/to/file2': [
+            {'line': 0, 'column': 0, 'code': 'CVE-2019-19844 (Django: crafted email address allows account takeover)',
+             'message': 'Django before 1.11.27, 2.x before 2.2.9, and 3.x before 3.0.1 allows account takeover.'}
+        ]
+    }
+
+
 class PylintJSONParserTestCase(ParserTestCaseMixin, unittest.TestCase):
     parser = PARSERS['pylint-json']
     linter_output_file_name = 'pylint-json.txt'


### PR DESCRIPTION
Adding another lintly parser `Trivy`. It can scan docker image, repo and file systems. Currently in readme I have mentioned instructions  running it in fs mode. But parser will work even if you change arguments.